### PR TITLE
Format transfer value

### DIFF
--- a/apps/envio/package.json
+++ b/apps/envio/package.json
@@ -12,17 +12,18 @@
     "start": "ts-node generated/src/Index.bs.js"
   },
   "devDependencies": {
-    "@types/chai": "^4.3.11",    
+    "@types/chai": "^4.3.11",
     "@types/mocha": "10.0.6",
     "@types/node": "20.8.8",
+    "chai": "4.3.10",
+    "mocha": "10.2.0",
     "ts-mocha": "^10.0.0",
     "ts-node": "10.9.1",
-    "typescript": "5.2.2",
-    "chai": "4.3.10",
-    "mocha": "10.2.0"
+    "typescript": "5.2.2"
   },
   "dependencies": {
-    "envio": "2.13.0"
+    "envio": "2.13.0",
+    "viem": "2.21.0"
   },
   "optionalDependencies": {
     "generated": "./generated"

--- a/apps/envio/pnpm-lock.yaml
+++ b/apps/envio/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       envio:
         specifier: 2.13.0
         version: 2.13.0(typescript@5.2.2)
+      viem:
+        specifier: 2.21.0
+        version: 2.21.0(typescript@5.2.2)
     devDependencies:
       '@types/chai':
         specifier: ^4.3.11

--- a/apps/envio/schema.graphql
+++ b/apps/envio/schema.graphql
@@ -5,7 +5,7 @@ type Space_Transfer {
   asset: String!
   from: String!
   to: String!
-  value: BigInt!
+  value: String!
 }
 
 type StationRegistry_ModuleKeeperUpdated {

--- a/apps/envio/src/space/native-received.ts
+++ b/apps/envio/src/space/native-received.ts
@@ -1,5 +1,6 @@
 import { Space, Space_Transfer } from "generated";
 import { ZERO_ADDRESS } from "../../constants";
+import { formatUnits } from "viem";
 
 Space.NativeReceived.handler(async ({ event, context }) => {
   const entity: Space_Transfer = {
@@ -9,7 +10,7 @@ Space.NativeReceived.handler(async ({ event, context }) => {
     asset: ZERO_ADDRESS,
     from: event.params.from,
     to: event.srcAddress,
-    value: event.params.amount,
+    value: formatUnits(event.params.amount, 18),
   };
 
   context.Space_Transfer.set(entity);

--- a/apps/envio/src/space/transfer.ts
+++ b/apps/envio/src/space/transfer.ts
@@ -1,5 +1,6 @@
 import { Space_Transfer, USDC } from "generated";
 import { getSpaceAddresses } from "../utils/get-space-addresses";
+import { formatUnits } from "viem";
 
 USDC.Transfer.handler(async ({ event, context }) => {
   const spaceAddresses = await getSpaceAddresses(context);
@@ -12,7 +13,7 @@ USDC.Transfer.handler(async ({ event, context }) => {
       asset: event.srcAddress,
       from: event.params.from,
       to: event.params.to,
-      value: event.params.value,
+      value: formatUnits(event.params.value, 6),
     };
 
     context.Space_Transfer.set(entity);


### PR DESCRIPTION
### Changelog:
- Updated `schema.graphql` to update the `Space_Transfer` value field type from `BigInt` to `String`;
- Formatted the transfer value based on the asset's decimals; 