### PR TITLE
Store `Space` address in the `StationRegistry` context

### DIFF
--- a/apps/envio/constants/index.ts
+++ b/apps/envio/constants/index.ts
@@ -1,1 +1,4 @@
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
+
+// Address of the {StationRegistry} contract deployed at deterministic address across chains
+export const STATION_REGISTRY_ADDRESS = "0xe1026Ab8272746dc93Efcd1423355F3b23E3e0aB";

--- a/apps/envio/package.json
+++ b/apps/envio/package.json
@@ -22,7 +22,7 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "envio": "2.13.0",
+    "envio": "2.15.0",
     "viem": "2.21.0"
   },
   "optionalDependencies": {

--- a/apps/envio/pnpm-lock.yaml
+++ b/apps/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 2.13.0
-        version: 2.13.0(typescript@5.2.2)
+        specifier: 2.15.0
+        version: 2.15.0(typescript@5.2.2)
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.2.2)
@@ -557,28 +557,28 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  envio-darwin-arm64@2.13.0:
-    resolution: {integrity: sha512-r/Yo5ttxWsNje5xhjfm/CS5JGXreAGuve6fzsrsf/TSYUpAQ5mgUWdTnKh8ttFXkxXOPJJNTRQWvqKO/wZHC1g==}
+  envio-darwin-arm64@2.15.0:
+    resolution: {integrity: sha512-n9LqIWSZfK+lIxwD0ZrSh5GE5OAZEVULkQgIVPCXib8Ba8NIk7ANJuy+rqPEUyMV6t6eoG9C87YcnPPUfmqk3A==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@2.13.0:
-    resolution: {integrity: sha512-vsvImvMPI9HTYSSCee4RFn1gv7Z+WFAFsTBwAKsEO4flSFm34i+67kLjduPr6RCUAJefIRx9feTWk6CnOcdZug==}
+  envio-darwin-x64@2.15.0:
+    resolution: {integrity: sha512-khqO+mISZMasuQpfGqS3AMIF3GSMcYS7w6Or+aJhiV5Eop6wrakfp99JDyHtch3MfPqw39QxXCsBi5Ox8Y9Z6g==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@2.13.0:
-    resolution: {integrity: sha512-ZgI7SRH8gIAm/0FtSn7sE+7adMfdra+LbSbVfO5RQGXIZEScdcVAfU11Y8A6hug/c7Xu77AWcHnJZXZBLBV1Qw==}
+  envio-linux-arm64@2.15.0:
+    resolution: {integrity: sha512-rz4qnIQuM+qSTS5Vy/d1PD79Vz4/SvnfEm6IJn8J8gR2KNwCgiG9b8uUBd4jZ4W+Vwf6QMpKudS88+n1Gd2Ljg==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64@2.13.0:
-    resolution: {integrity: sha512-5YdzcF/DfyuH+ranHaZW+ZX97bjX+sidVrTI9Z7XhZ3LdQKddonmG+LlNk6GKLWGOofMTBLXM3hkLeaHVbYELQ==}
+  envio-linux-x64@2.15.0:
+    resolution: {integrity: sha512-8QCkD83z5Y5EwJ3/wCBP/1io+/zrQg0MmynJJoI+EacNhyktffUCvkSRTLX8UY5HdMHAigiRRG9IyNlkbTj8bA==}
     cpu: [x64]
     os: [linux]
 
-  envio@2.13.0:
-    resolution: {integrity: sha512-nyXtcCGBrbSJY0yCC2Wrlif2Kg9b9eKyX7HpWOthqrDKpIzDc2xdLJV6HL8XF0eU4NKuD0KAs6P6qUl5GJ7tGw==}
+  envio@2.15.0:
+    resolution: {integrity: sha512-9XjOVLdvGvZy6YfjCxfWl2sdnRBMUN5SeyYZ3IoLjv0B1yOubSiQTR89WNc+4/lcJ63M/pqif8CWtsHyg+BlmA==}
     hasBin: true
 
   es-define-property@1.0.1:
@@ -1858,29 +1858,29 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@2.13.0:
+  envio-darwin-arm64@2.15.0:
     optional: true
 
-  envio-darwin-x64@2.13.0:
+  envio-darwin-x64@2.15.0:
     optional: true
 
-  envio-linux-arm64@2.13.0:
+  envio-linux-arm64@2.15.0:
     optional: true
 
-  envio-linux-x64@2.13.0:
+  envio-linux-x64@2.15.0:
     optional: true
 
-  envio@2.13.0(typescript@5.2.2):
+  envio@2.15.0(typescript@5.2.2):
     dependencies:
       '@envio-dev/hypersync-client': 0.6.3
       rescript: 11.1.3
       rescript-schema: 9.1.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.2.2)
     optionalDependencies:
-      envio-darwin-arm64: 2.13.0
-      envio-darwin-x64: 2.13.0
-      envio-linux-arm64: 2.13.0
-      envio-linux-x64: 2.13.0
+      envio-darwin-arm64: 2.15.0
+      envio-darwin-x64: 2.15.0
+      envio-linux-arm64: 2.15.0
+      envio-linux-x64: 2.15.0
     transitivePeerDependencies:
       - bufferutil
       - typescript

--- a/apps/envio/pnpm-lock.yaml
+++ b/apps/envio/pnpm-lock.yaml
@@ -50,14 +50,17 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@envio-dev/hypersync-client':
-        specifier: 0.6.3
-        version: 0.6.3
+        specifier: 0.6.2
+        version: 0.6.2
       '@glennsl/rescript-fetch':
         specifier: 0.2.0
         version: 0.2.0
       '@rescript/react':
         specifier: 0.12.1
         version: 0.12.1(react-dom@19.0.0(react@18.2.0))(react@18.2.0)
+      '@ryyppy/rescript-promise':
+        specifier: 2.1.0
+        version: 2.1.0
       bignumber.js:
         specifier: 9.1.2
         version: 9.1.2
@@ -104,20 +107,23 @@ importers:
         specifier: 18.2.0
         version: 18.2.0
       rescript:
-        specifier: 11.1.3
-        version: 11.1.3
+        specifier: 11.1.0
+        version: 11.1.0
       rescript-envsafe:
-        specifier: 5.0.0
-        version: 5.0.0(rescript-schema@9.1.0(rescript@11.1.3))(rescript@11.1.3)
+        specifier: 4.2.0
+        version: 4.2.0(rescript-schema@8.0.0(rescript@11.1.0))(rescript@11.1.0)
+      rescript-express:
+        specifier: 0.4.1
+        version: 0.4.1(express@4.19.2)
       rescript-schema:
-        specifier: 9.1.0
-        version: 9.1.0(rescript@11.1.3)
+        specifier: 8.0.0
+        version: 8.0.0(rescript@11.1.0)
       root:
         specifier: ../.
         version: link:..
       viem:
-        specifier: 2.21.0
-        version: 2.21.0(typescript@5.2.2)
+        specifier: 1.16.6
+        version: 1.16.6(typescript@5.2.2)
       yargs:
         specifier: 17.7.2
         version: 17.7.2
@@ -126,6 +132,9 @@ packages:
 
   '@adraffy/ens-normalize@1.10.0':
     resolution: {integrity: sha512-nA9XHtlAkYfJxY7bce8DcN7eKxWWCWkU+1GR9d+U6MbNpfwQp8TI7vqOsBsMcHoT4mBu2kypKoSKnghEzOOq5Q==}
+
+  '@adraffy/ens-normalize@1.9.4':
+    resolution: {integrity: sha512-UK0bHA7hh9cR39V+4gl2/NnBBjoXIxkuWAPCaY4X7fbH4L/azIi7ilWOCjMUYfpJgraLUAqkRi2BqrjME8Rynw==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -139,10 +148,22 @@ packages:
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
 
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.2':
+    resolution: {integrity: sha512-dDIuQqEgARR1JYodbGkmck1i9qbYEidc4Kw4DOrRKQ0uZFwflI4o8wm3P+G/ofc1iXwp4pm7jqNUGzZDpK9pqA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
     resolution: {integrity: sha512-w4OLJaq3lD03iXPJxLnPpoxOduvzCfEe2nYtamvIRLPB2SlbxnB5EF5dSyFs6WKh1x4PMsksQOUKeCcOtQPZow==}
     engines: {node: '>= 10'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@envio-dev/hypersync-client-darwin-x64@0.6.2':
+    resolution: {integrity: sha512-NGlgkmosAzlZ1EuQ5/djkg6sQI/dgVX+XGOLI6Zden0ca2zr/ByBRA7yCKxpwZHYynFN2FoMsMGSRY8jj6XQWw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
     os: [darwin]
 
   '@envio-dev/hypersync-client-darwin-x64@0.6.3':
@@ -151,14 +172,32 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.2':
+    resolution: {integrity: sha512-p2LQSaOSgjVvvFHOGHnPHTnsDHCWNEG78J29guZyqWojmaxTaR4eGyFEknla7eO0w58EIUGEBTF0+EJ7duMimg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
   '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
     resolution: {integrity: sha512-5pI0N6W7W0L7LpgN76BAWRsC+NPOvrlvBEq8IjlBUS47vqZALvcJj3gYNkm466tUBQ4q4tF1x48k7MFKtoO8aw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.2':
+    resolution: {integrity: sha512-/kIL9Q0e5hM0g6cvdCHL93LMu+OCnwQAGKQHCj2TKKUjVpWFNb0Ki5PMgJhQ8mimEBFsJAnErVK+HrugLTlaVQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
   '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
     resolution: {integrity: sha512-jL3sxWVyTJuKdO5y/0tu1EtWSox+nJdpmr7rdVW1w0gLk4ewzWORp9cl5pXkpqM4MUsjJz+NkcQKsUquGYBkKg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.2':
+    resolution: {integrity: sha512-4r5hA/zyxUjWBDYYeXLCl5pBfSI9njEIPuLMFXajjVcAvSXRtBhmgVwa3JrjjCxZ8aLfqk9vvPkb/KgYfrbXXw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
@@ -169,11 +208,21 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.2':
+    resolution: {integrity: sha512-VgsSwmDAgvpgo9QsIiwIp9IN+h3g0U/7zrCrvNAMj+lsMHJPZ7L0cfN58dQUr84wL8domJGJrnMKUtu/Yf49ow==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
   '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
     resolution: {integrity: sha512-AINzLdjqU+y6ZiHnxorjFlrGNIw/AAJ80YXABYzokvGhDTF9qupjR1gdZo4sQEumgrRyg7fiG8QnsZVEm6V/zA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
+
+  '@envio-dev/hypersync-client@0.6.2':
+    resolution: {integrity: sha512-wgp0UmblW8yn/q5NMkVYPFDvOmgHWPTibl/QJYyYK2KXqAMHssUjP07ayduiZCexQOZ94Agpv4SvmYxQNjGBIA==}
+    engines: {node: '>= 10'}
 
   '@envio-dev/hypersync-client@0.6.3':
     resolution: {integrity: sha512-Lr5WyMZBK1cI++kAQLM/zd62NfUM60A3KWTKgeNew4NOghfoY5YZr99C7vo+CMYePXskYBR+ul+5iNPoHqkFrw==}
@@ -216,11 +265,20 @@ packages:
       react: '>=18.0.0'
       react-dom: '>=18.0.0'
 
+  '@ryyppy/rescript-promise@2.1.0':
+    resolution: {integrity: sha512-+dW6msBrj2Lr2hbEMX+HoWCvN89qVjl94RwbYWJgHQuj8jm/izdPC0YzxgpGoEFdeAEW2sOozoLcYHxT6o5WXQ==}
+
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
+  '@scure/bip32@1.3.2':
+    resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
+
   '@scure/bip32@1.4.0':
     resolution: {integrity: sha512-sVUpc0Vq3tXCkDGYVWGIZTRfnvu8LoTDaev7vbwh0omSvVORONr960MQWdKqJDCReIEmTj3PAr73O3aoxz7OPg==}
+
+  '@scure/bip39@1.2.1':
+    resolution: {integrity: sha512-Z3/Fsz1yr904dduJD0NpiyRHhRYHdcnyh73FZWiV+/qhWi83wNJ3NWolYqCEN+ZWsUz2TWwajJggcRE9r1zUYg==}
 
   '@scure/bip39@1.3.0':
     resolution: {integrity: sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==}
@@ -254,6 +312,17 @@ packages:
 
   '@types/yoga-layout@1.9.2':
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
+
+  abitype@0.9.8:
+    resolution: {integrity: sha512-puLifILdm+8sjyss4S+fsUN09obiT1g2YW6CtcQF+QDzxR0euzgEB29MZujC6zMk2a6SVmtttq1fc6+YFA7WYQ==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+      zod: ^3 >=3.19.1
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+      zod:
+        optional: true
 
   abitype@1.0.5:
     resolution: {integrity: sha512-YzDhti7cjlfaBhHutMaboYB21Ha3rXR9QTkNJFzYC4kC8YclaiwPBBBJY8ejFdu2wnJeZCVZSMlQJ7fi8S6hsw==}
@@ -835,6 +904,11 @@ packages:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
 
+  isows@1.0.3:
+    resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
+    peerDependencies:
+      ws: '*'
+
   isows@1.0.4:
     resolution: {integrity: sha512-hEzjY+x9u9hPmBom9IIAqdJCwNLax+xrPb51vEPpERoFlIxgmZcHzsT5jKG06nvInKOBGvReAVz80Umed5CczQ==}
     peerDependencies:
@@ -971,6 +1045,80 @@ packages:
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
+
+  npm@10.9.2:
+    resolution: {integrity: sha512-iriPEPIkoMYUy3F6f3wwSZAU93E0Eg6cHwIR6jzzOXWSy+SD/rOODEs74cVONHKSx2obXtuUoyidVEhISrisgQ==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+    bundledDependencies:
+      - '@isaacs/string-locale-compare'
+      - '@npmcli/arborist'
+      - '@npmcli/config'
+      - '@npmcli/fs'
+      - '@npmcli/map-workspaces'
+      - '@npmcli/package-json'
+      - '@npmcli/promise-spawn'
+      - '@npmcli/redact'
+      - '@npmcli/run-script'
+      - '@sigstore/tuf'
+      - abbrev
+      - archy
+      - cacache
+      - chalk
+      - ci-info
+      - cli-columns
+      - fastest-levenshtein
+      - fs-minipass
+      - glob
+      - graceful-fs
+      - hosted-git-info
+      - ini
+      - init-package-json
+      - is-cidr
+      - json-parse-even-better-errors
+      - libnpmaccess
+      - libnpmdiff
+      - libnpmexec
+      - libnpmfund
+      - libnpmhook
+      - libnpmorg
+      - libnpmpack
+      - libnpmpublish
+      - libnpmsearch
+      - libnpmteam
+      - libnpmversion
+      - make-fetch-happen
+      - minimatch
+      - minipass
+      - minipass-pipeline
+      - ms
+      - node-gyp
+      - nopt
+      - normalize-package-data
+      - npm-audit-report
+      - npm-install-checks
+      - npm-package-arg
+      - npm-pick-manifest
+      - npm-profile
+      - npm-registry-fetch
+      - npm-user-validate
+      - p-map
+      - pacote
+      - parse-conflict-json
+      - proc-log
+      - qrcode-terminal
+      - read
+      - semver
+      - spdx-expression-parse
+      - ssri
+      - supports-color
+      - tar
+      - text-table
+      - tiny-relative-date
+      - treeverse
+      - validate-npm-package-name
+      - which
+      - write-file-atomic
 
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -1134,16 +1282,31 @@ packages:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
 
-  rescript-envsafe@5.0.0:
-    resolution: {integrity: sha512-xSQbNsFSSQEynvLWUYtI7GJJhzicACLTq5aO1tjgK0N2Vcm9qlrkcLSmnU8tTohebEu9zgm1V/xYY+oGeQgLvA==}
+  rescript-envsafe@4.2.0:
+    resolution: {integrity: sha512-EpoEkyFzYZa2xzvOwHMAeW/dagqN0WXTL03IBJuZlE+33baKSTQEQ60L20472fPTJRxYaDv14A0UXglPvhSDsA==}
     peerDependencies:
       rescript: 11.x
-      rescript-schema: 9.x
+      rescript-schema: 6.x || 7.x || 8.x
+
+  rescript-express@0.4.1:
+    resolution: {integrity: sha512-R+xAQKANfIFAIcxhQrkLn58IZQwhMZuQpVCH6UtTRNLWqlVtaogG9z4Rt0MQZgqYOjvrOtt51P0hOmYGg/90Fw==}
+    peerDependencies:
+      express: ^4.17.1
+
+  rescript-schema@8.0.0:
+    resolution: {integrity: sha512-+i/us90Q73HeRZ9Y6BXfogb0BXpfwDmmFhHI+dZkvnzGOLMQEx3kowXv78LfP2ujpedwpN85/aqEPXRb+eBtog==}
+    peerDependencies:
+      rescript: 11.x
 
   rescript-schema@9.1.0:
     resolution: {integrity: sha512-zD6hpg59HF6QJ3rnmhFV6mYtbfUd6ZTu20osL93aR9fdc3GTIX6N8Fy/6btgZ9a35A2NAzTvCgh/dz3EK7qfAw==}
     peerDependencies:
       rescript: 11.x
+
+  rescript@11.1.0:
+    resolution: {integrity: sha512-9la2Dv+ACylQ77I8s4spPu1JnLZXbH5WgxcLHLLUBWgFFSiv0wXqgzWztrBIZqwFgVX5BYcwldUqUVcEzdCyHg==}
+    engines: {node: '>=10'}
+    hasBin: true
 
   rescript@11.1.3:
     resolution: {integrity: sha512-bI+yxDcwsv7qE34zLuXeO8Qkc2+1ng5ErlSjnUIZdrAWKoGzHXpJ6ZxiiRBUoYnoMsgRwhqvrugIFyNgWasmsw==}
@@ -1364,6 +1527,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  viem@1.16.6:
+    resolution: {integrity: sha512-jcWcFQ+xzIfDwexwPJRvCuCRJKEkK9iHTStG7mpU5MmuSBpACs4nATBDyXNFtUiyYTFzLlVEwWkt68K0nCSImg==}
+    peerDependencies:
+      typescript: '>=5.0.4'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
   viem@2.21.0:
     resolution: {integrity: sha512-9g3Gw2nOU6t4bNuoDI5vwVExzIxseU0J7Jjx10gA2RNQVrytIrLxggW++tWEe3w4mnnm/pS1WgZFjQ/QKf/nHw==}
     peerDependencies:
@@ -1410,6 +1581,18 @@ packages:
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  ws@8.13.0:
+    resolution: {integrity: sha512-x9vcZYTrFPC7aSIbj7sRCYo7L/Xb8Iy+pW0ng0wt2vCJv7M9HOMy0UoN3rr+IFC7hb7vXoqS+P9ktyLLLhO+LA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
     peerDependenciesMeta:
       bufferutil:
         optional: true
@@ -1464,6 +1647,11 @@ packages:
     resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
     engines: {node: '>=12'}
 
+  yarn@1.22.22:
+    resolution: {integrity: sha512-prL3kGtyG7o9Z9Sv8IPfBNrWTDmXB4Qbes8A9rEzt6wkJV8mUvoirjU0Mp3GGAU06Y0XQyA3/2/RQFVuK7MTfg==}
+    engines: {node: '>=4.0.0'}
+    hasBin: true
+
   yn@2.0.0:
     resolution: {integrity: sha512-uTv8J/wiWTgUTg+9vLTi//leUl5vDQS6uii/emeTb2ssY7vl6QWf2fFbIIGjnhjvbdKlU0ed7QPgY1htTC86jQ==}
     engines: {node: '>=4'}
@@ -1484,6 +1672,8 @@ snapshots:
 
   '@adraffy/ens-normalize@1.10.0': {}
 
+  '@adraffy/ens-normalize@1.9.4': {}
+
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
@@ -1496,23 +1686,53 @@ snapshots:
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
 
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.2':
+    optional: true
+
   '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
+    optional: true
+
+  '@envio-dev/hypersync-client-darwin-x64@0.6.2':
     optional: true
 
   '@envio-dev/hypersync-client-darwin-x64@0.6.3':
     optional: true
 
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.2':
+    optional: true
+
   '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
+    optional: true
+
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.2':
     optional: true
 
   '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
     optional: true
 
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.2':
+    optional: true
+
   '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
+    optional: true
+
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.2':
     optional: true
 
   '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
     optional: true
+
+  '@envio-dev/hypersync-client@0.6.2':
+    dependencies:
+      npm: 10.9.2
+      yarn: 1.22.22
+    optionalDependencies:
+      '@envio-dev/hypersync-client-darwin-arm64': 0.6.2
+      '@envio-dev/hypersync-client-darwin-x64': 0.6.2
+      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.2
+      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.2
+      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.2
+      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.2
 
   '@envio-dev/hypersync-client@0.6.3':
     optionalDependencies:
@@ -1553,12 +1773,25 @@ snapshots:
       react: 18.2.0
       react-dom: 19.0.0(react@18.2.0)
 
+  '@ryyppy/rescript-promise@2.1.0': {}
+
   '@scure/base@1.1.9': {}
+
+  '@scure/bip32@1.3.2':
+    dependencies:
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/base': 1.1.9
 
   '@scure/bip32@1.4.0':
     dependencies:
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
+      '@scure/base': 1.1.9
+
+  '@scure/bip39@1.2.1':
+    dependencies:
+      '@noble/hashes': 1.3.2
       '@scure/base': 1.1.9
 
   '@scure/bip39@1.3.0':
@@ -1588,6 +1821,10 @@ snapshots:
       undici-types: 5.25.3
 
   '@types/yoga-layout@1.9.2': {}
+
+  abitype@0.9.8(typescript@5.2.2):
+    optionalDependencies:
+      typescript: 5.2.2
 
   abitype@1.0.5(typescript@5.2.2):
     optionalDependencies:
@@ -2178,6 +2415,10 @@ snapshots:
 
   is-unicode-supported@0.1.0: {}
 
+  isows@1.0.3(ws@8.13.0):
+    dependencies:
+      ws: 8.13.0
+
   isows@1.0.4(ws@8.17.1):
     dependencies:
       ws: 8.17.1
@@ -2299,6 +2540,8 @@ snapshots:
       whatwg-url: 5.0.0
 
   normalize-path@3.0.0: {}
+
+  npm@10.9.2: {}
 
   object-assign@4.1.1: {}
 
@@ -2479,14 +2722,24 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  rescript-envsafe@5.0.0(rescript-schema@9.1.0(rescript@11.1.3))(rescript@11.1.3):
+  rescript-envsafe@4.2.0(rescript-schema@8.0.0(rescript@11.1.0))(rescript@11.1.0):
     dependencies:
-      rescript: 11.1.3
-      rescript-schema: 9.1.0(rescript@11.1.3)
+      rescript: 11.1.0
+      rescript-schema: 8.0.0(rescript@11.1.0)
+
+  rescript-express@0.4.1(express@4.19.2):
+    dependencies:
+      express: 4.19.2
+
+  rescript-schema@8.0.0(rescript@11.1.0):
+    dependencies:
+      rescript: 11.1.0
 
   rescript-schema@9.1.0(rescript@11.1.3):
     dependencies:
       rescript: 11.1.3
+
+  rescript@11.1.0: {}
 
   rescript@11.1.3: {}
 
@@ -2722,6 +2975,23 @@ snapshots:
 
   vary@1.1.2: {}
 
+  viem@1.16.6(typescript@5.2.2):
+    dependencies:
+      '@adraffy/ens-normalize': 1.9.4
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@scure/bip32': 1.3.2
+      '@scure/bip39': 1.2.1
+      abitype: 0.9.8(typescript@5.2.2)
+      isows: 1.0.3(ws@8.13.0)
+      ws: 8.13.0
+    optionalDependencies:
+      typescript: 5.2.2
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+      - zod
+
   viem@2.21.0(typescript@5.2.2):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
@@ -2779,6 +3049,8 @@ snapshots:
 
   ws@7.5.10: {}
 
+  ws@8.13.0: {}
+
   ws@8.17.1: {}
 
   ws@8.5.0: {}
@@ -2815,6 +3087,8 @@ snapshots:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
+
+  yarn@1.22.22: {}
 
   yn@2.0.0: {}
 

--- a/apps/envio/schema.graphql
+++ b/apps/envio/schema.graphql
@@ -47,6 +47,12 @@ type StationRegistry_SignerRemoved {
   signer: String!
 }
 
+type StationRegistry_Spaces {
+  id: ID!
+  chainId: String!
+  spaces: [String!]!
+}
+
 type StationRegistry_SpaceCreated {
   id: ID!
   owner: String!

--- a/apps/envio/src/space/transfer.ts
+++ b/apps/envio/src/space/transfer.ts
@@ -1,27 +1,34 @@
 import { formatUnits } from "viem";
 import { Space_Transfer, USDC } from "generated";
-import { STATION_REGISTRY_ADDRESS } from "../../constants";
+import { STATION_REGISTRY_ADDRESS, ZERO_ADDRESS } from "../../constants";
 
-USDC.Transfer.handler(async ({ event, context }) => {
-  // Retrieve the {StationRegistry_Spaces} context entity
-  const stationRegistry = await context.StationRegistry_Spaces.get(`${event.chainId}_${STATION_REGISTRY_ADDRESS}`);
+USDC.Transfer.handlerWithLoader({
+  loader: async ({ event, context }) => {
+    // Retrieve the {StationRegistry_Spaces} context entity
+    const stationRegistry = await context.StationRegistry_Spaces.get(`${event.chainId}_${STATION_REGISTRY_ADDRESS}`);
 
-  // Get the Space deployed on the current chain ID through the `StationRegistry` factory contract
-  const spaceAddresses = stationRegistry?.spaces;
+    // Get the Space deployed on the current chain ID through the `StationRegistry` factory contract
+    const spaceAddresses = stationRegistry?.spaces;
 
-  // Filter and store only the USDC transfers that involve a Space address
-  if (spaceAddresses && (spaceAddresses.includes(event.params.from) || spaceAddresses.includes(event.params.to))) {
-    const entity: Space_Transfer = {
-      id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
-      timestamp: BigInt(event.block.timestamp),
-      chainId: event.chainId.toString(),
-      asset: event.srcAddress,
-      from: event.params.from,
-      to: event.params.to,
-      value: formatUnits(event.params.value, 6),
-      hash: event.transaction.hash,
-    };
+    return { spaceAddresses };
+  },
+  handler: async ({ event, context, loaderReturn }) => {
+    const { spaceAddresses } = loaderReturn;
 
-    context.Space_Transfer.set(entity);
-  }
+    // Filter and store only the USDC transfers that involve a Space address
+    if (spaceAddresses && (spaceAddresses.includes(event.params.from) || spaceAddresses.includes(event.params.to))) {
+      const entity: Space_Transfer = {
+        id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+        timestamp: BigInt(event.block.timestamp),
+        chainId: event.chainId.toString(),
+        asset: event.srcAddress,
+        from: event.params.from,
+        to: event.params.to,
+        value: formatUnits(event.params.value, 6),
+        hash: event.transaction.hash,
+      };
+
+      context.Space_Transfer.set(entity);
+    }
+  },
 });

--- a/apps/envio/src/space/transfer.ts
+++ b/apps/envio/src/space/transfer.ts
@@ -1,11 +1,16 @@
-import { Space_Transfer, USDC } from "generated";
-import { getSpaceAddresses } from "../utils/get-space-addresses";
 import { formatUnits } from "viem";
+import { Space_Transfer, USDC } from "generated";
+import { STATION_REGISTRY_ADDRESS } from "../../constants";
 
 USDC.Transfer.handler(async ({ event, context }) => {
-  const spaceAddresses = await getSpaceAddresses(context);
+  // Retrieve the {StationRegistry_Spaces} context entity
+  const stationRegistry = await context.StationRegistry_Spaces.get(`${event.chainId}_${STATION_REGISTRY_ADDRESS}`);
 
-  if (spaceAddresses.includes(event.params.from) || spaceAddresses.includes(event.params.to)) {
+  // Get the Space deployed on the current chain ID through the `StationRegistry` factory contract
+  const spaceAddresses = stationRegistry?.spaces;
+
+  // Filter and store only the USDC transfers that involve a Space address
+  if (spaceAddresses && (spaceAddresses.includes(event.params.from) || spaceAddresses.includes(event.params.to))) {
     const entity: Space_Transfer = {
       id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
       timestamp: BigInt(event.block.timestamp),

--- a/apps/envio/src/station-registry/space-created.ts
+++ b/apps/envio/src/station-registry/space-created.ts
@@ -1,5 +1,4 @@
 import { StationRegistry, StationRegistry_SpaceCreated } from "generated";
-import { addSpaceAddress } from "../utils/get-space-addresses";
 
 StationRegistry.SpaceCreated.handler(async ({ event, context }) => {
   const entity: StationRegistry_SpaceCreated = {
@@ -9,18 +8,26 @@ StationRegistry.SpaceCreated.handler(async ({ event, context }) => {
     space: event.params.space,
   };
 
-  // Add the Space address to the cached list of addresses
-  addSpaceAddress(event.params.space);
-
+  // Add the `SpaceCreated` event to the `StationRegistry_SpaceCreated` context entity
   context.StationRegistry_SpaceCreated.set(entity);
+
+  // Get the `StationRegistry` entity ID based on the event chain ID
+  const STATION_REGISTRY_ID = `${event.chainId}_${event.srcAddress}`;
+
+  // Get the `StationRegistry` entity based on the event chain ID
+  const stationRegistry = await context.StationRegistry_Spaces.get(STATION_REGISTRY_ID);
+
+  // Retrieve the list of deployed Space addresses through the `StationRegistry` factory contract
+  const spaces = stationRegistry?.spaces || [];
+
+  // Add the new Space address to the list of deployed Space addresses
+  spaces.push(event.params.space);
+
+  // Update the `StationRegistry_Spaces` context entity with the new list of deployed Space addresses
+  context.StationRegistry_Spaces.set({ id: STATION_REGISTRY_ID, chainId: event.chainId.toString(), spaces });
 });
 
 /// Handler to register a `Space` contract through the {SpaceCreated} event
-StationRegistry.SpaceCreated.contractRegister(
-  ({ event, context }) => {
-    context.addSpace(event.params.space);
-  },
-  {
-    preRegisterDynamicContracts: true, // reduces indexing time
-  }
-);
+StationRegistry.SpaceCreated.contractRegister(({ event, context }) => {
+  context.addSpace(event.params.space);
+});


### PR DESCRIPTION
### Changelog:
- Added a new `StationRegistry_Spaces` type to store all `Space` addresses by chain ID;
- Filtered USDC transfers by deployed `Space`s through the `StationRegistry` factory contract;
- Updated `envio` to `v2.15.0`;