### PR TITLE
build: bump envio version, add RPC fallback and other improvements

### DIFF
--- a/apps/envio/config.yaml
+++ b/apps/envio/config.yaml
@@ -29,14 +29,14 @@ contracts:
       - event: Transfer(address indexed from, address indexed to, uint256 value)
 networks:
   - id: 84532 # Base Sepolia
-    start_block: 21451964
+    start_block: 25689188
     contracts:
       - name: StationRegistry # A reference to the global StationRegistry contract definition
         address:
           - 0x05880666779aeE8ff9492740c64cc83268C1B8FC
       - name: Space # A reference to the global Space contract definition
   - id: 11155111 # Ethereum Sepolia
-    start_block: 7638308
+    start_block: 8318596
     contracts:
       - name: StationRegistry # A reference to the global StationRegistry contract definition
         address:

--- a/apps/envio/config.yaml
+++ b/apps/envio/config.yaml
@@ -29,6 +29,12 @@ contracts:
       - event: Transfer(address indexed from, address indexed to, uint256 value)
 networks:
   - id: 84532 # Base Sepolia
+    rpc:
+      - url: https://base-sepolia.drpc.org
+        for: fallback
+      - url: https://sepolia.base.org
+        for: fallback
+        initial_block_interval: 1000
     start_block: 25689188
     contracts:
       - name: StationRegistry # A reference to the global StationRegistry contract definition
@@ -36,6 +42,12 @@ networks:
           - 0x05880666779aeE8ff9492740c64cc83268C1B8FC
       - name: Space # A reference to the global Space contract definition
   - id: 11155111 # Ethereum Sepolia
+    rpc:
+      - url: https://ethereum-sepolia-rpc.publicnode.com
+        for: fallback
+      - url: https://sepolia.drpc.org
+        for: fallback
+        initial_block_interval: 1000
     start_block: 8318596
     contracts:
       - name: StationRegistry # A reference to the global StationRegistry contract definition

--- a/apps/envio/constants/index.ts
+++ b/apps/envio/constants/index.ts
@@ -1,8 +1,5 @@
 export const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 
-// Address of the {StationRegistry} contract deployed at deterministic address across chains
-export const STATION_REGISTRY_ADDRESS = "0xe1026Ab8272746dc93Efcd1423355F3b23E3e0aB";
-
 // Address of the {USDC} contract deployed across chains
 export const USDC_ADDRESS = {
   84532: "0x036CbD53842c5426634e7929541eC2318f3dCF7e",

--- a/apps/envio/package.json
+++ b/apps/envio/package.json
@@ -23,7 +23,7 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "envio": "2.16.0",
+    "envio": "2.21.0",
     "viem": "2.21.0"
   },
   "optionalDependencies": {

--- a/apps/envio/pnpm-lock.yaml
+++ b/apps/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 2.16.0
-        version: 2.16.0(typescript@5.2.2)
+        specifier: 2.21.0
+        version: 2.21.0(typescript@5.2.2)
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.2.2)
@@ -50,8 +50,8 @@ importers:
         specifier: 1.4.0
         version: 1.4.0
       '@envio-dev/hypersync-client':
-        specifier: 0.6.3
-        version: 0.6.3
+        specifier: 0.6.5
+        version: 0.6.5
       '@glennsl/rescript-fetch':
         specifier: 0.2.0
         version: 0.2.0
@@ -85,9 +85,6 @@ importers:
       js-sdsl:
         specifier: 4.4.2
         version: 4.4.2
-      node-fetch:
-        specifier: 2.7.0
-        version: 2.7.0
       pino:
         specifier: 8.16.1
         version: 8.16.1
@@ -108,10 +105,10 @@ importers:
         version: 11.1.3
       rescript-envsafe:
         specifier: 5.0.0
-        version: 5.0.0(rescript-schema@9.1.0(rescript@11.1.3))(rescript@11.1.3)
+        version: 5.0.0(rescript-schema@9.3.0(rescript@11.1.3))(rescript@11.1.3)
       rescript-schema:
-        specifier: 9.1.0
-        version: 9.1.0(rescript@11.1.3)
+        specifier: 9.3.0
+        version: 9.3.0(rescript@11.1.3)
       root:
         specifier: ../.
         version: link:..
@@ -139,44 +136,44 @@ packages:
     resolution: {integrity: sha512-eCSBUTgl8KbPyxky8cecDRLCYu2C1oFV4AZ72bEsI+TxXEvaljaL2kgttfzfu7gW+M89eCz55s49uF2t+YMTWA==}
     engines: {node: '>=10'}
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
-    resolution: {integrity: sha512-w4OLJaq3lD03iXPJxLnPpoxOduvzCfEe2nYtamvIRLPB2SlbxnB5EF5dSyFs6WKh1x4PMsksQOUKeCcOtQPZow==}
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.5':
+    resolution: {integrity: sha512-BjFmDFd+7QKuEkjlvwQjKy9b+ZWidkZHyKPjKSDg6u3KJe+fr+uY3rsW9TXNscUxJvl8YxJ2mZl0svOH7ukTyQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-darwin-x64@0.6.3':
-    resolution: {integrity: sha512-zh98zCbm2cse/iIzyMs1YCcA1iI1U/j4Yex1xBVaEa1ogzQSK9peS6M+NygzdmlwPqr7K9rUQ/U56ICRl67fWw==}
+  '@envio-dev/hypersync-client-darwin-x64@0.6.5':
+    resolution: {integrity: sha512-XT1l6bfsXgZqxh8BZbPoP/3Zk0Xvwzr/ZKVmzXR5ZhPxDgEVUJMg4Rd1oy8trd1K+uevqOr2DbuIGvM7k2hb8A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
-    resolution: {integrity: sha512-5pI0N6W7W0L7LpgN76BAWRsC+NPOvrlvBEq8IjlBUS47vqZALvcJj3gYNkm466tUBQ4q4tF1x48k7MFKtoO8aw==}
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.5':
+    resolution: {integrity: sha512-MPTXagjE8/XQhNiZokIJWYqDcizf++TKOjbfYgCzlS6jzwgmeZs6WYcdYFC3FSaJyc9GX4diJ4GKOgbpR4XWtw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
-    resolution: {integrity: sha512-jL3sxWVyTJuKdO5y/0tu1EtWSox+nJdpmr7rdVW1w0gLk4ewzWORp9cl5pXkpqM4MUsjJz+NkcQKsUquGYBkKg==}
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.5':
+    resolution: {integrity: sha512-DUDY19T2O+ciniP8RHWEv6ziaCdVkkVVLhfXiovpLy+oR1K/+h7osUHD1HCPolibaU3V2EDpqTDhKBtvPXUGaQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
-    resolution: {integrity: sha512-4rAh9x3PEWIweih731lWVEUGm+qrIHouElqZgXfTcZS6KkPeDnSYKVw10K5EyDuDtZla/NccEr0pJmcvpui5Ew==}
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.5':
+    resolution: {integrity: sha512-VolsHvPrk5PAdHN0ht1iowwXz7bwJO0L5qDuw3eSKF4qHuAzlwImB1CRhJrMIaE8McsDnN6fSlqDeTPRmzS/Ug==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
-    resolution: {integrity: sha512-AINzLdjqU+y6ZiHnxorjFlrGNIw/AAJ80YXABYzokvGhDTF9qupjR1gdZo4sQEumgrRyg7fiG8QnsZVEm6V/zA==}
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.5':
+    resolution: {integrity: sha512-D+bkkWbCsbgaTrhyVdXHysKUCVzFpkWoxmaHnm2anad7+yKKfx15afYirtZMTKc7CLkYqganghN4QsBsEHl3Iw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
 
-  '@envio-dev/hypersync-client@0.6.3':
-    resolution: {integrity: sha512-Lr5WyMZBK1cI++kAQLM/zd62NfUM60A3KWTKgeNew4NOghfoY5YZr99C7vo+CMYePXskYBR+ul+5iNPoHqkFrw==}
+  '@envio-dev/hypersync-client@0.6.5':
+    resolution: {integrity: sha512-mii+ponVo5ZmVOlEtJxyugGHuIuzYp5bVfr88mCuRwcWZIkNrWfad/aAW6H7YNe63E0gq0ePtRDrkLzlpAUuGQ==}
     engines: {node: '>= 10'}
 
   '@glennsl/rescript-fetch@0.2.0':
@@ -557,28 +554,28 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  envio-darwin-arm64@2.16.0:
-    resolution: {integrity: sha512-IGDxnYyl4GIAsdWhcYuTUrhkMFteB+HPSOeRAte9SnkzbbiTkpy/CNqCQl6F003WF92nrWf2yzZrX+f/FTXy4w==}
+  envio-darwin-arm64@2.21.0:
+    resolution: {integrity: sha512-QJziOX/4FJjUXEq8jmET0i5mvpmndLeJ4HRo+kpjERCsL+jT4b3GAxbsivC0ERgzEOqfqZ7KzwB0+PpTK6tHuQ==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@2.16.0:
-    resolution: {integrity: sha512-DDFYbTls0dsEdxpqEIF6qbz3gNLGH0qwpXR4yMcf3Jy/iO2sVzvhJqd0DbR64Z/Dxs6zvcHca46GbQQdegcdXA==}
+  envio-darwin-x64@2.21.0:
+    resolution: {integrity: sha512-uJkMWXPovOQGDCoX9k5vy3GjGLIPMwKc/FK5ZC8pjyfG2OplQGhld3mDASNHmcLWkrYFLeNZqgy1kJAH6ZHvjw==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@2.16.0:
-    resolution: {integrity: sha512-Na2fKWJB5FXNxwNJEoGVp8i+fU1DZXQ6ujmB/U5hpolN1cqe6w9b0+DZFRK7lhCaz8s19BgaecM6H8cmYKkpNg==}
+  envio-linux-arm64@2.21.0:
+    resolution: {integrity: sha512-sKtEDovM85CTn94EE9enyae8R5GsAVdqZ6lqd9K4nqehNcEAezNaetDck/JOpTf4cW8O1Lu1uyqN3qcBmQ46DA==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64@2.16.0:
-    resolution: {integrity: sha512-sqmPLTR/lOf5tsedgFqBhbDqfM+HgRXa/mrpX0MAqKTrZ5SS1FnrC74PS/fiJkTDI13/sCXkRbz2CunWi7HS9w==}
+  envio-linux-x64@2.21.0:
+    resolution: {integrity: sha512-GQs0no1jB7Ico2WZ5Yvj4dbiNZBla83K+aKImcek4AEWs8eZpjbp6tvrTSah1PJql/n+rO1dOAbOmvdpaa1m+w==}
     cpu: [x64]
     os: [linux]
 
-  envio@2.16.0:
-    resolution: {integrity: sha512-DWWK11+qLPM70gSerGKccZHymPWV9x1OskytszAoq7IA98wazPNs0RFpTxfU88tQlybHyvHVToDG5JIGMZ78+w==}
+  envio@2.21.0:
+    resolution: {integrity: sha512-tklu4mqEHG1EzBvPLqXPDAflVShr3DxsjwYVXfFWI4tKP8YD3Rpw3GvsZ50lS7ZUnOnSSZcKLGnvoCr+by4bYw==}
     hasBin: true
 
   es-define-property@1.0.1:
@@ -959,15 +956,6 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
-  node-fetch@2.7.0:
-    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
-    engines: {node: 4.x || >=6.0.0}
-    peerDependencies:
-      encoding: ^0.1.0
-    peerDependenciesMeta:
-      encoding:
-        optional: true
-
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
@@ -1140,10 +1128,13 @@ packages:
       rescript: 11.x
       rescript-schema: 9.x
 
-  rescript-schema@9.1.0:
-    resolution: {integrity: sha512-zD6hpg59HF6QJ3rnmhFV6mYtbfUd6ZTu20osL93aR9fdc3GTIX6N8Fy/6btgZ9a35A2NAzTvCgh/dz3EK7qfAw==}
+  rescript-schema@9.3.0:
+    resolution: {integrity: sha512-NiHAjlhFKZCmNhx/Ij40YltCEJJgVNhBWTN/ZfagTg5hdWWuvCiUacxZv+Q/QQolrAhTnHnCrL7RDvZBogHl5A==}
     peerDependencies:
       rescript: 11.x
+    peerDependenciesMeta:
+      rescript:
+        optional: true
 
   rescript@11.1.3:
     resolution: {integrity: sha512-bI+yxDcwsv7qE34zLuXeO8Qkc2+1ng5ErlSjnUIZdrAWKoGzHXpJ6ZxiiRBUoYnoMsgRwhqvrugIFyNgWasmsw==}
@@ -1284,9 +1275,6 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
-  tr46@0.0.3:
-    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-
   ts-mocha@10.1.0:
     resolution: {integrity: sha512-T0C0Xm3/WqCuF2tpa0GNGESTBoKZaiqdUP8guNv4ZY316AFXlyidnrzQ1LUrCT0Wb1i3J0zFTgOh/55Un44WdA==}
     engines: {node: '>= 6.X.X'}
@@ -1374,12 +1362,6 @@ packages:
 
   webauthn-p256@0.0.5:
     resolution: {integrity: sha512-drMGNWKdaixZNobeORVIqq7k5DsRC9FnG201K2QjeOoQLmtSDaSsVZdkg6n5jUALJKcAG++zBPJXmv6hy0nWFg==}
-
-  webidl-conversions@3.0.1:
-    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-
-  whatwg-url@5.0.0:
-    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   widest-line@3.1.0:
     resolution: {integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==}
@@ -1496,32 +1478,32 @@ snapshots:
     dependencies:
       '@elastic/ecs-helpers': 1.1.0
 
-  '@envio-dev/hypersync-client-darwin-arm64@0.6.3':
+  '@envio-dev/hypersync-client-darwin-arm64@0.6.5':
     optional: true
 
-  '@envio-dev/hypersync-client-darwin-x64@0.6.3':
+  '@envio-dev/hypersync-client-darwin-x64@0.6.5':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.3':
+  '@envio-dev/hypersync-client-linux-arm64-gnu@0.6.5':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.3':
+  '@envio-dev/hypersync-client-linux-x64-gnu@0.6.5':
     optional: true
 
-  '@envio-dev/hypersync-client-linux-x64-musl@0.6.3':
+  '@envio-dev/hypersync-client-linux-x64-musl@0.6.5':
     optional: true
 
-  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.3':
+  '@envio-dev/hypersync-client-win32-x64-msvc@0.6.5':
     optional: true
 
-  '@envio-dev/hypersync-client@0.6.3':
+  '@envio-dev/hypersync-client@0.6.5':
     optionalDependencies:
-      '@envio-dev/hypersync-client-darwin-arm64': 0.6.3
-      '@envio-dev/hypersync-client-darwin-x64': 0.6.3
-      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.3
-      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.3
-      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.3
-      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.3
+      '@envio-dev/hypersync-client-darwin-arm64': 0.6.5
+      '@envio-dev/hypersync-client-darwin-x64': 0.6.5
+      '@envio-dev/hypersync-client-linux-arm64-gnu': 0.6.5
+      '@envio-dev/hypersync-client-linux-x64-gnu': 0.6.5
+      '@envio-dev/hypersync-client-linux-x64-musl': 0.6.5
+      '@envio-dev/hypersync-client-win32-x64-msvc': 0.6.5
 
   '@glennsl/rescript-fetch@0.2.0': {}
 
@@ -1858,29 +1840,29 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@2.16.0:
+  envio-darwin-arm64@2.21.0:
     optional: true
 
-  envio-darwin-x64@2.16.0:
+  envio-darwin-x64@2.21.0:
     optional: true
 
-  envio-linux-arm64@2.16.0:
+  envio-linux-arm64@2.21.0:
     optional: true
 
-  envio-linux-x64@2.16.0:
+  envio-linux-x64@2.21.0:
     optional: true
 
-  envio@2.16.0(typescript@5.2.2):
+  envio@2.21.0(typescript@5.2.2):
     dependencies:
-      '@envio-dev/hypersync-client': 0.6.3
+      '@envio-dev/hypersync-client': 0.6.5
       rescript: 11.1.3
-      rescript-schema: 9.1.0(rescript@11.1.3)
+      rescript-schema: 9.3.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.2.2)
     optionalDependencies:
-      envio-darwin-arm64: 2.16.0
-      envio-darwin-x64: 2.16.0
-      envio-linux-arm64: 2.16.0
-      envio-linux-x64: 2.16.0
+      envio-darwin-arm64: 2.21.0
+      envio-darwin-x64: 2.21.0
+      envio-linux-arm64: 2.21.0
+      envio-linux-x64: 2.21.0
     transitivePeerDependencies:
       - bufferutil
       - typescript
@@ -2294,10 +2276,6 @@ snapshots:
 
   negotiator@0.6.3: {}
 
-  node-fetch@2.7.0:
-    dependencies:
-      whatwg-url: 5.0.0
-
   normalize-path@3.0.0: {}
 
   object-assign@4.1.1: {}
@@ -2479,13 +2457,13 @@ snapshots:
 
   require-directory@2.1.1: {}
 
-  rescript-envsafe@5.0.0(rescript-schema@9.1.0(rescript@11.1.3))(rescript@11.1.3):
+  rescript-envsafe@5.0.0(rescript-schema@9.3.0(rescript@11.1.3))(rescript@11.1.3):
     dependencies:
       rescript: 11.1.3
-      rescript-schema: 9.1.0(rescript@11.1.3)
+      rescript-schema: 9.3.0(rescript@11.1.3)
 
-  rescript-schema@9.1.0(rescript@11.1.3):
-    dependencies:
+  rescript-schema@9.3.0(rescript@11.1.3):
+    optionalDependencies:
       rescript: 11.1.3
 
   rescript@11.1.3: {}
@@ -2645,8 +2623,6 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
-  tr46@0.0.3: {}
-
   ts-mocha@10.1.0(mocha@10.2.0):
     dependencies:
       mocha: 10.2.0
@@ -2744,13 +2720,6 @@ snapshots:
     dependencies:
       '@noble/curves': 1.4.0
       '@noble/hashes': 1.4.0
-
-  webidl-conversions@3.0.1: {}
-
-  whatwg-url@5.0.0:
-    dependencies:
-      tr46: 0.0.3
-      webidl-conversions: 3.0.1
 
   widest-line@3.1.0:
     dependencies:


### PR DESCRIPTION
### Changelog:
- Bumps envio version to `v2.21.0`;
- Improves resilience with RPC fallback config;
- Updates `start_block` fields;
- Removes unused constant;