### PR TITLE
build: add mainnet configs

### DIFF
--- a/apps/envio/config.yaml
+++ b/apps/envio/config.yaml
@@ -28,6 +28,32 @@ contracts:
       - event: NativeReceived(address indexed from, uint256 amount)
       - event: Transfer(address indexed from, address indexed to, uint256 value)
 networks:
+  - id: 8453 # Base
+    rpc:
+      - url: https://base-mainnet.g.alchemy.com/v2/%env:ALCHEMY_KEY%
+        for: fallback
+      - url: https://base.llamarpc.com
+        for: fallback
+        initial_block_interval: 1000
+    start_block: 31167037
+    contracts:
+      - name: StationRegistry # A reference to the global StationRegistry contract definition
+        address:
+          - 0xA678C48d5860dA60B5C2A44B02315dFbaED6D91a
+      - name: Space # A reference to the global Space contract definition
+  - id: 1 # Ethereum
+    rpc:
+      - url: https://eth-mainnet.g.alchemy.com/v2/%env:ALCHEMY_KEY%
+        for: fallback
+      - url: https://eth.llamarpc.com
+        for: fallback
+        initial_block_interval: 1000
+    start_block: 31167037
+    contracts:
+      - name: StationRegistry # A reference to the global StationRegistry contract definition
+        address:
+          - 0xA678C48d5860dA60B5C2A44B02315dFbaED6D91a
+      - name: Space # A reference to the global Space contract definition
   - id: 84532 # Base Sepolia
     rpc:
       - url: https://base-sepolia.drpc.org

--- a/apps/envio/package.json
+++ b/apps/envio/package.json
@@ -23,7 +23,7 @@
     "typescript": "5.2.2"
   },
   "dependencies": {
-    "envio": "2.21.0",
+    "envio": "2.21.5",
     "viem": "2.21.0"
   },
   "optionalDependencies": {

--- a/apps/envio/pnpm-lock.yaml
+++ b/apps/envio/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       envio:
-        specifier: 2.21.0
-        version: 2.21.0(typescript@5.2.2)
+        specifier: 2.21.5
+        version: 2.21.5(typescript@5.2.2)
       viem:
         specifier: 2.21.0
         version: 2.21.0(typescript@5.2.2)
@@ -554,28 +554,28 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  envio-darwin-arm64@2.21.0:
-    resolution: {integrity: sha512-QJziOX/4FJjUXEq8jmET0i5mvpmndLeJ4HRo+kpjERCsL+jT4b3GAxbsivC0ERgzEOqfqZ7KzwB0+PpTK6tHuQ==}
+  envio-darwin-arm64@2.21.5:
+    resolution: {integrity: sha512-YiP6M0AVIeP9oycry2HD9DllIEuue3XfXMWuFdekC7Yi5hJ+MTI8uVFk7OlFlu/JO7P3MximqQY+DjmFTup6fg==}
     cpu: [arm64]
     os: [darwin]
 
-  envio-darwin-x64@2.21.0:
-    resolution: {integrity: sha512-uJkMWXPovOQGDCoX9k5vy3GjGLIPMwKc/FK5ZC8pjyfG2OplQGhld3mDASNHmcLWkrYFLeNZqgy1kJAH6ZHvjw==}
+  envio-darwin-x64@2.21.5:
+    resolution: {integrity: sha512-Ue67veQWWRdKsfaWuGG0VULkvytB1PMz3m914jxq7nGDgv4WGFnry9mvezoCLu3bVlvZf+WQK6lVqiqyXsvU0w==}
     cpu: [x64]
     os: [darwin]
 
-  envio-linux-arm64@2.21.0:
-    resolution: {integrity: sha512-sKtEDovM85CTn94EE9enyae8R5GsAVdqZ6lqd9K4nqehNcEAezNaetDck/JOpTf4cW8O1Lu1uyqN3qcBmQ46DA==}
+  envio-linux-arm64@2.21.5:
+    resolution: {integrity: sha512-qoAj6XlA/fbivIlSYfM56z9A3KblMBQnK6x13GW5soFIC+bPoB3Z+KlAr5Z2o8JEwGkuFw+i+RResX1tAWAvnQ==}
     cpu: [arm64]
     os: [linux]
 
-  envio-linux-x64@2.21.0:
-    resolution: {integrity: sha512-GQs0no1jB7Ico2WZ5Yvj4dbiNZBla83K+aKImcek4AEWs8eZpjbp6tvrTSah1PJql/n+rO1dOAbOmvdpaa1m+w==}
+  envio-linux-x64@2.21.5:
+    resolution: {integrity: sha512-k0UWu7jXJLOuBcbZvhutgLd4jqzhdDf9ZU5S3YDIpSKy4y0huNV/pDxkkPf1TohVv60uE9Venau+r8rg4BOL+g==}
     cpu: [x64]
     os: [linux]
 
-  envio@2.21.0:
-    resolution: {integrity: sha512-tklu4mqEHG1EzBvPLqXPDAflVShr3DxsjwYVXfFWI4tKP8YD3Rpw3GvsZ50lS7ZUnOnSSZcKLGnvoCr+by4bYw==}
+  envio@2.21.5:
+    resolution: {integrity: sha512-tYKRvvYwEIdmvj1IWwU9WKa9j8OnAQ5qYIareCg6MSW8wa29oGYHPpTD+JO0ArGS0e9uBqVUnMrQEKiO641y/w==}
     hasBin: true
 
   es-define-property@1.0.1:
@@ -1840,29 +1840,29 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  envio-darwin-arm64@2.21.0:
+  envio-darwin-arm64@2.21.5:
     optional: true
 
-  envio-darwin-x64@2.21.0:
+  envio-darwin-x64@2.21.5:
     optional: true
 
-  envio-linux-arm64@2.21.0:
+  envio-linux-arm64@2.21.5:
     optional: true
 
-  envio-linux-x64@2.21.0:
+  envio-linux-x64@2.21.5:
     optional: true
 
-  envio@2.21.0(typescript@5.2.2):
+  envio@2.21.5(typescript@5.2.2):
     dependencies:
       '@envio-dev/hypersync-client': 0.6.5
       rescript: 11.1.3
       rescript-schema: 9.3.0(rescript@11.1.3)
       viem: 2.21.0(typescript@5.2.2)
     optionalDependencies:
-      envio-darwin-arm64: 2.21.0
-      envio-darwin-x64: 2.21.0
-      envio-linux-arm64: 2.21.0
-      envio-linux-x64: 2.21.0
+      envio-darwin-arm64: 2.21.5
+      envio-darwin-x64: 2.21.5
+      envio-linux-arm64: 2.21.5
+      envio-linux-x64: 2.21.5
     transitivePeerDependencies:
       - bufferutil
       - typescript


### PR DESCRIPTION
### Changelog:
- Adds configuration for Base and Ethereum deployments;
- Bumps `envio` to v2.21.5;