### PR TITLE
feat: listen for Space outgoing ETH transfers

### DIFF
--- a/apps/envio/config.yaml
+++ b/apps/envio/config.yaml
@@ -27,6 +27,7 @@ contracts:
     events:
       - event: NativeReceived(address indexed from, uint256 amount)
       - event: Transfer(address indexed from, address indexed to, uint256 value)
+      - event: AssetWithdrawn(address indexed to, address indexed asset, uint256 amount)
 unordered_multichain_mode: true
 networks:
   - id: 8453 # Base

--- a/apps/envio/src/space/asset-withdrawn.ts
+++ b/apps/envio/src/space/asset-withdrawn.ts
@@ -1,0 +1,22 @@
+import { Space, Space_Transfer } from "generated";
+import { ZERO_ADDRESS } from "../../constants";
+import { formatUnits } from "viem";
+
+Space.AssetWithdrawn.handler(async ({ event, context }) => {
+  if (event.params.asset !== ZERO_ADDRESS) {
+    return;
+  }
+
+  const entity: Space_Transfer = {
+    id: `${event.chainId}_${event.block.number}_${event.logIndex}`,
+    timestamp: BigInt(event.block.timestamp),
+    chainId: event.chainId.toString(),
+    asset: ZERO_ADDRESS,
+    from: event.srcAddress,
+    to: event.params.to,
+    value: formatUnits(event.params.amount, 18),
+    hash: event.transaction.hash,
+  };
+
+  context.Space_Transfer.set(entity);
+});

--- a/apps/envio/src/space/index.ts
+++ b/apps/envio/src/space/index.ts
@@ -1,2 +1,3 @@
 import "./transfer";
 import "./native-received";
+import "./asset-withdrawn";


### PR DESCRIPTION
Listens for outgoing ETH transfer for a Space, based on the `AssetWithdrawn` event emitted by the smart account, when the `asset` is the zero-address.